### PR TITLE
remove deps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
+Remotes: moodymudskipper/cutr
 biocViews:
 Depends: 
     R (>= 3.5.0)
@@ -21,6 +22,7 @@ Imports:
     AnnotationDbi,
     Biobase,
     Biostrings,
+    cutr,
     dplyr,
     tidyr,
     ggplot2,
@@ -28,11 +30,10 @@ Imports:
     MSnbase,
     purrr,
     rlang,
+    robustbase,
     stats,
-    Hmisc,
     tibble,
-    utils,
-    robustbase
+    utils
 Suggests: 
     knitr,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 biocViews:
 Depends: 
-    R (>= 2.10)
+    R (>= 3.5.0)
 Imports: 
     AnnotationDbi,
     Biobase,
@@ -30,11 +30,11 @@ Imports:
     rlang,
     stats,
     Hmisc,
-    stringr,
     tibble,
     utils,
     robustbase
 Suggests: 
-    testthat,
     knitr,
-    rmarkdown
+    rmarkdown,
+    stringr,
+    testthat

--- a/R/estimate_incorporation.R
+++ b/R/estimate_incorporation.R
@@ -54,7 +54,7 @@ estimate_incorporation <- function(psm_infile,
   # Extract the non cRAP UniProt accessions associated with each cRAP protein
   crap.accessions <- crap.fasta %>%
     pull(desc) %>%
-    stringr::str_extract_all("(?<=\\|).*?(?=\\|)") %>%
+    regmatches(.data, gregexpr("(?<=\\|).*?(?=\\|)", .data, perl = TRUE)) %>%
     unlist()
 
   peptide_data <- parse_features(utils::read.delim(peptide_infile),

--- a/R/tmt_qc_plots.R
+++ b/R/tmt_qc_plots.R
@@ -142,7 +142,7 @@ plot_below_notch_per_prot <- function(notch_per_protein){
   p_notch_per_protein <- notch_per_protein %>%
     group_by(.data$n_below, sample=remove_x(.data$sample)) %>%
     tally() %>%
-    ggplot(aes(sample, n, fill=Hmisc::cut2(
+    ggplot(aes(sample, n, fill=cutr::cutf2(
       .data$n_below, cuts=c(0, 1, 3, 5, 8, 12, 20, 43)))) +
     geom_bar(stat='identity', position='fill') +
     scale_fill_manual(name='# PSMs below notch', values=c('grey', get_cat_palette(6))) +
@@ -204,7 +204,7 @@ plot_missing_SN <- function(obj,
 
   p <- data.frame('n_missing'=n_missing,
                   'sn'=fData(obj)[[sn_column]]) %>%
-    mutate(binned_sn=Hmisc::cut2(.data$sn, g=bins, digits=1)) %>%
+    mutate(binned_sn=cutr::cutf2(.data$sn, g=bins, digits=1)) %>%
     filter(is.finite(.data$sn)) %>%
     group_by(.data$n_missing, .data$binned_sn) %>%
     tally() %>%
@@ -246,7 +246,7 @@ plot_missing_SN_per_sample <- function(obj,
     merge(fData(obj)[,sn_column, drop=FALSE], by.x='PSM_id', by.y='row.names') %>%
     filter(is.finite(.data$Average.Reporter.SN))
 
-  sn_per_sample$binned_sn <- Hmisc::cut2(sn_per_sample[[sn_column]], g=bins, digits=1)
+  sn_per_sample$binned_sn <- cutr::cutf2(sn_per_sample[[sn_column]], g=bins, digits=1)
 
   p <- sn_per_sample %>%
     group_by(.data$sample, .data$binned_sn,

--- a/man/center_normalise_to_ref.Rd
+++ b/man/center_normalise_to_ref.Rd
@@ -19,7 +19,7 @@ normalised
 \description{
 Center-median normalisation is a simple normalisation method
 that is appropriate for relative abundance proteomics such as isobaric tagging.
-This can be achieved with \code{MSnbase::normalise(method='diff.center')}. However,
+This can be achieved with \code{MSnbase::normalise(method='diff.median')}. However,
 for some experimental designs, the normalisation should be against the medians
 in another dataset. For example, for PTM studies, one may wish to isobaric
 tag samples, pool, and then PTM-enriched, with the enriched sample quantified


### PR DESCRIPTION
- Removes `stringr` (which depends on the very large `stringi` package) from Imports to Suggests.
- Replaces the `cut2()` function from `Hmisc` (which has lots of dependencies including `stringr` and `stringi`) with the functionally identical `cutf2()` from the `cutr` package.

By removing `stringi` as a recursive dependency, the total Travis build time is reduced from ~1 h to ~10 min. Also reducing `camprotR` dependencies to a minimum is probably a good idea in general.