### PR TITLE
speeds up add_peptide_positions by dropping Biostrings::match

### DIFF
--- a/R/ptm.R
+++ b/R/ptm.R
@@ -323,8 +323,10 @@ add_peptide_positions <- function(obj,
     if (!protein %in% names(proteome)) {
       return(c(NA, NA))
     }
-    peptide_start <- Biostrings::start(Biostrings::matchPattern(sequence, proteome[[protein]]))
-    peptide_end <- Biostrings::end(Biostrings::matchPattern(sequence, proteome[[protein]]))
+
+    m <- gregexpr(sprintf('(?=(%s))', sequence), proteome[[protein]], perl=T)[[1]]
+    peptide_start <- attr(m,"capture.start")
+    peptide_end <- attr(m,"capture.start") + attr(m,"capture.length") - 1
 
     if (length(peptide_start) != 1) {
       return(c(NA, NA))
@@ -334,7 +336,6 @@ add_peptide_positions <- function(obj,
       return(c(peptide_start, peptide_end))
     }
   }
-
 
   obj[, c('peptide_start', 'peptide_end')] <- t(apply(
     obj,


### PR DESCRIPTION
The speed (or lack of) of `add_peptide_positions`  has been a pain for ages. This speeds it up about 4-fold by replacing `Biostrings::matchPattern` which appeared to be part of the issue from a quick profiling. 

@csdaw - Any other ideas for optimisation?